### PR TITLE
Z-index bug with first menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nested",
     "conditional"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://github.com/kbravh/netlify-cms-widget-nested-select",
   "license": "MIT",
   "main": "dist/main.js",

--- a/src/NestedSelectControl.js
+++ b/src/NestedSelectControl.js
@@ -81,6 +81,8 @@ export default class Control extends React.Component {
     return (
       <div className={classNameWrapper}>
         <Select
+          className="firstSelect"
+          classNamePrefix="firstSelect"
           id={forID}
           value={this.convertToOption(value.split(delimiter)[0]) || ''}
           options={this.state.primaryOptions}

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
+.firstSelect__menu {
+    z-index: 2 !important;
+}
+
 .secondSelect {
     margin-top: 15px;
     width: 90%;


### PR DESCRIPTION
The default styling for the react-select menu applies a z-index of 1 to the menu components. This causes the menu options of the first select to be hidden behind the second select entirely.

Closes #19